### PR TITLE
Pass the request's origin to `set()` and `setRecoveryEmail()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # bedrock-authn-token-http ChangeLog
 
+## 9.2.0 - 2026-07-dd
+
+### Added
+- Derive an optional `requestOrigin` from the request's `Origin` header
+  (falling back to the `Referer` header's origin) and pass it to
+  `brAuthnToken.set()` and `brAuthnToken.setRecoveryEmail()`, causing it to
+  be included in the `bedrock-authn-token.notify` and
+  `bedrock-authn-token.recoveryEmail.change` events.
+
+### Changed
+- Update `@bedrock/authn-token` peer dependency to `^12.1.0`.
+
 ## 9.1.0 - 2026-02-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   `brAuthnToken.set()` and `brAuthnToken.setRecoveryEmail()`, causing it to
   be included in the `bedrock-authn-token.notify` and
   `bedrock-authn-token.recoveryEmail.change` events.
+- Add a mandatory `requestOriginAllowList` config option
+  (`config['authn-token-http'].requestOriginAllowList`) that gates which
+  derived origins are honored; unlisted origins are treated as absent.
+  Defaults to a computed value admitting the server's own origin.
 
 ### Changed
 - Update `@bedrock/authn-token` peer dependency to `^12.1.0`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,16 @@
 /*!
  * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
  */
-import {config} from '@bedrock/core';
+import {config, util} from '@bedrock/core';
+
+const cc = util.config.main.computer();
 
 const cfg = config['authn-token-http'] = {};
+
+// defaults to this server's own origin so single-origin apps work unconfigured
+cc('authn-token-http.requestOriginAllowList', () => {
+  return [config.server.baseUri];
+});
 
 cfg.cookies = {};
 // client id to be baked into cookies that is used in client registration

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         // note: anyone can request a nonce, no authentication required
         await brAuthnToken.set({
           accountId, email, type, clientId,
+          requestOrigin: _getRequestOrigin({req}),
           authenticationMethod, requiredAuthenticationMethods, typeOptions
         });
         res.status(204).end();
@@ -94,6 +95,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
         const result = await brAuthnToken.set({
           accountId, email, type, hash, clientId, serviceId,
+          requestOrigin: _getRequestOrigin({req}),
           authenticationMethod, requiredAuthenticationMethods
         });
 
@@ -324,7 +326,10 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     asyncHandler(async (req, res) => {
       const {account: accountId, recoveryEmail} = req.body;
       _checkAccount({req, accountId});
-      await brAuthnToken.setRecoveryEmail({accountId, recoveryEmail});
+      await brAuthnToken.setRecoveryEmail({
+        accountId, recoveryEmail,
+        requestOrigin: _getRequestOrigin({req}),
+      });
       res.status(204).end();
     }));
 });
@@ -338,6 +343,19 @@ function _checkAccount({req, accountId}) {
         public: true
       });
   }
+}
+
+function _getRequestOrigin({req}) {
+  let origin = req.get('origin');
+  const referer = req.get('referer');
+  if(!origin && referer) {
+    try {
+      origin = new URL(referer).origin;
+    } catch(e) {
+      return undefined;
+    }
+  }
+  return origin;
 }
 
 function _getSessionAuthenticationData({req}) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -346,6 +346,7 @@ function _checkAccount({req, accountId}) {
 }
 
 function _getRequestOrigin({req}) {
+  const {requestOriginAllowList} = config['authn-token-http'];
   let origin = req.get('origin');
   const referer = req.get('referer');
   if(!origin && referer) {
@@ -355,7 +356,7 @@ function _getRequestOrigin({req}) {
       return undefined;
     }
   }
-  return origin;
+  return requestOriginAllowList.includes(origin) ? origin : undefined;
 }
 
 function _getSessionAuthenticationData({req}) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@bedrock/account": "^10.0.0",
-    "@bedrock/authn-token": "^12.0.0",
+    "@bedrock/authn-token": "^12.1.0",
     "@bedrock/core": "^6.3.0",
     "@bedrock/express": "^8.3.1",
     "@bedrock/passport": "^12.0.0",

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -13,6 +13,8 @@ import {httpClient} from '@digitalbazaar/http-client';
 import {mockData} from './mock.data.js';
 import setCookie from 'set-cookie-parser';
 
+const serverOrigin = config.server.baseUri;
+
 let accounts;
 
 const passportStubSettings = {email: null};
@@ -190,6 +192,68 @@ describe('api', () => {
       res.status.should.equal(204);
       events.length.should.equal(1);
       should.not.exist(events[0].requestOrigin);
+    });
+    it('should not include "requestOrigin" in the notify event when ' +
+      'origin header is not in requestOriginAllowList', async function() {
+      const type = 'nonce';
+      let err;
+      let res;
+      const accountId = accounts['beta@example.com'].account.id;
+      stubPassportStub('beta@example.com');
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        res = await httpClient.post(`${baseURL}/${type}`, {
+          agent, json: {
+            account: accountId,
+            requiredAuthenticationMethods: ['login-email-challenge'],
+            authenticationMethod: 'login-email-challenge',
+          }, headers: {
+            origin: 'https://evil.example'
+          }
+        });
+      } catch(e) {
+        err = e;
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      assertNoError(err);
+      should.exist(res);
+      res.status.should.equal(204);
+      events.length.should.equal(1);
+      should.not.exist(events[0].requestOrigin);
+    });
+    it('should derive "requestOrigin" in the notify event when baseUri ' +
+      'is included in requestOriginAllowList', async function() {
+      const type = 'nonce';
+      let err;
+      let res;
+      const accountId = accounts['beta@example.com'].account.id;
+      stubPassportStub('beta@example.com');
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        res = await httpClient.post(`${baseURL}/${type}`, {
+          agent, json: {
+            account: accountId,
+            requiredAuthenticationMethods: ['login-email-challenge'],
+            authenticationMethod: 'login-email-challenge',
+          }, headers: {
+            origin: serverOrigin
+          }
+        });
+      } catch(e) {
+        err = e;
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      assertNoError(err);
+      should.exist(res);
+      res.status.should.equal(204);
+      events.length.should.equal(1);
+      events[0].requestOrigin.should.equal(serverOrigin);
     });
     it('should include "requestOrigin" in the recoveryEmail.change event',
       async function() {

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2019-2026 Digital Bazaar, Inc.
  */
+import * as bedrock from '@bedrock/core';
 import * as brAuthnToken from '@bedrock/authn-token';
 import * as helpers from './helpers.js';
 import {_deserializeUser, passport} from '@bedrock/passport';
@@ -63,6 +64,8 @@ const loginURL = `https://${config.server.host}` +
   `${config['authn-token-http'].routes.login}`;
 const requirementsURL = `https://${config.server.host}` +
   `${config['authn-token-http'].routes.requirements}`;
+const recoveryURL = `https://${config.server.host}` +
+  `${config['authn-token-http'].routes.recovery}`;
 
 describe('api', () => {
   describe('post /', () => {
@@ -95,6 +98,130 @@ describe('api', () => {
       res.status.should.equal(204);
       should.not.exist(res.data);
     });
+    it('should include "requestOrigin" in the notify event when an ' +
+      '"Origin" header is present', async function() {
+      const type = 'nonce';
+      let err;
+      let res;
+      // the `requestOrigin` tests use `beta` to avoid exhausting `alpha`'s
+      // budget under the 5-pending-nonce-per-account limit
+      const accountId = accounts['beta@example.com'].account.id;
+      stubPassportStub('beta@example.com');
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        res = await httpClient.post(`${baseURL}/${type}`, {
+          agent, json: {
+            account: accountId,
+            requiredAuthenticationMethods: ['login-email-challenge'],
+            authenticationMethod: 'login-email-challenge'
+          }, headers: {
+            origin: 'https://wallet.example'
+          }
+        });
+      } catch(e) {
+        err = e;
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      assertNoError(err);
+      should.exist(res);
+      res.status.should.equal(204);
+      events.length.should.equal(1);
+      events[0].requestOrigin.should.equal('https://wallet.example');
+    });
+    it('should derive "requestOrigin" from the "Referer" header when no ' +
+      '"Origin" header is present', async function() {
+      const type = 'nonce';
+      let err;
+      let res;
+      const accountId = accounts['beta@example.com'].account.id;
+      stubPassportStub('beta@example.com');
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        res = await httpClient.post(`${baseURL}/${type}`, {
+          agent, json: {
+            account: accountId,
+            requiredAuthenticationMethods: ['login-email-challenge'],
+            authenticationMethod: 'login-email-challenge'
+          }, headers: {
+            referer: 'https://wallet.example/some/page?q=1'
+          }
+        });
+      } catch(e) {
+        err = e;
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      assertNoError(err);
+      should.exist(res);
+      res.status.should.equal(204);
+      events.length.should.equal(1);
+      events[0].requestOrigin.should.equal('https://wallet.example');
+    });
+    it('should not include "requestOrigin" in the notify event when no ' +
+      '"Origin" or "Referer" header is present', async function() {
+      const type = 'nonce';
+      let err;
+      let res;
+      const accountId = accounts['beta@example.com'].account.id;
+      stubPassportStub('beta@example.com');
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        res = await httpClient.post(`${baseURL}/${type}`, {
+          agent, json: {
+            account: accountId,
+            requiredAuthenticationMethods: ['login-email-challenge'],
+            authenticationMethod: 'login-email-challenge'
+          }
+        });
+      } catch(e) {
+        err = e;
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      assertNoError(err);
+      should.exist(res);
+      res.status.should.equal(204);
+      events.length.should.equal(1);
+      should.not.exist(events[0].requestOrigin);
+    });
+    it('should include "requestOrigin" in the recoveryEmail.change event',
+      async function() {
+        let err;
+        let res;
+        const accountId = accounts['alpha@example.com'].account.id;
+        stubPassportStub('alpha@example.com');
+        const events = [];
+        const listener = event => events.push(event);
+        bedrock.events.on('bedrock-authn-token.recoveryEmail.change', listener);
+        try {
+          res = await httpClient.post(recoveryURL, {
+            agent, json: {
+              account: accountId,
+              recoveryEmail: 'alpha-recovery@example.com'
+            }, headers: {
+              origin: 'https://wallet.example'
+            }
+          });
+        } catch(e) {
+          err = e;
+        } finally {
+          bedrock.events.removeListener(
+            'bedrock-authn-token.recoveryEmail.change', listener);
+        }
+        assertNoError(err);
+        should.exist(res);
+        res.status.should.equal(204);
+        events.length.should.equal(1);
+        events[0].requestOrigin.should.equal('https://wallet.example');
+        events[0].newRecoveryEmail.should.equal('alpha-recovery@example.com');
+      });
     it('should create a `totp` token', async function() {
       const type = 'totp';
       let err;

--- a/test/package.json
+++ b/test/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@bedrock/account": "^10.0.0",
     "@bedrock/account-http": "^9.0.0",
-    "@bedrock/authn-token": "^12.0.0",
+    "@bedrock/authn-token": "^12.1.0",
     "@bedrock/authn-token-http": "file:..",
     "@bedrock/core": "^6.3.0",
     "@bedrock/express": "^8.3.1",

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,13 +1,14 @@
 /*!
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {config} from '@bedrock/core';
+import {config, util} from '@bedrock/core';
 import {fileURLToPath} from 'node:url';
 import path from 'node:path';
 import '@bedrock/account-http';
 import '@bedrock/https-agent';
 import '@bedrock/mongodb';
 
+const cc = util.config.main.computer();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
@@ -26,3 +27,9 @@ config['https-agent'].rejectUnauthorized = false;
 config['account-http'].autoLoginNewAccounts = true;
 
 config.express.useSession = true;
+
+// admit the test suite's wallet origin in addition to whatever this test
+// server's own computed origin happens to be
+cc('authn-token-http.requestOriginAllowList', () => {
+  return [config.server.baseUri, 'https://wallet.example'];
+});


### PR DESCRIPTION
Derives an optional `requestOrigin` from the request's `Origin` header (falling back to the `Referer` header's origin) and passes it to `brAuthnToken.set()` and `setRecoveryEmail()`, so the notify events carry the requesting frontend's origin. The value is intended for use downstream only as an allow-list lookup key. Bumps the `@bedrock/authn-token` peer dependency to `^12.1.0` — CI will stay red until that version is released (merge digitalbazaar/bedrock-authn-token#70 first). Release as 9.2.0.

**Updated 2026-07-17:** The origin allow list is now enforced here as a mandatory `requestOriginAllowList` config (computed default admits only the server's own origin; unlisted origins are stripped, never rejected), so every consumer of this package gets the safety check rather than relying on each app to add its own.
